### PR TITLE
suppress taskkill output

### DIFF
--- a/src/beamngpy/beamng.py
+++ b/src/beamngpy/beamng.py
@@ -205,8 +205,8 @@ class BeamNGpy:
 
         log.debug('Killing BeamNG process...')
         if os.name == "nt":
-            subprocess.call(
-                ['taskkill', '/F', '/T', '/PID', str(self.process.pid)])
+            with open(os.devnull, 'w') as devnull:
+                subprocess.call(['taskkill', '/F', '/T', '/PID', str(self.process.pid)], stdout=devnull, stderr=devnull)
         else:
             os.kill(self.process.pid, signal.SIGTERM)
 


### PR DESCRIPTION
at each run, taskkill outputs many lines like this:
SUCCESS: The process with PID 16732 (child process of PID 412) has been terminated.

In a repeated run of BeamNG, these lines clog the console