### PR TITLE
Implement #102 - Incorrect Pixel-Depth Scaling

### DIFF
--- a/src/beamngpy/sensors.py
+++ b/src/beamngpy/sensors.py
@@ -423,7 +423,8 @@ class Camera(Sensor):
 
     def __init__(self, pos, direction, fov, resolution, near_far=(NEAR, FAR),
                  colour=False, depth=False, depth_distance=(NEAR, FAR),
-                 annotation=False, instance=False, shmem=True):
+                 depth_inverse=False, annotation=False, instance=False,
+                 shmem=True):
         """
         The camera sensor is set up with a fixed offset position and
         directional vector to face relative to the vehicle. This means as the
@@ -463,6 +464,12 @@ class Camera(Sensor):
                                     than 50 would be mapped to white. All
                                     distances in-between are interpolated
                                     accordingly.
+            depth_inverse (bool): If true, depth values are inversed so that
+                                  geometry that is closer is white instead
+                                  of black, and geometry that is further is
+                                  black instead of white. This is more
+                                  typical behaviour of real-life stereo
+                                  cameras that output depth images.
             annotation (bool): Whether to output annotation information.
             instance (bool): Whether to output instance annotation information.
             shmem (bool): Whether to use shared memory for sensor data
@@ -478,6 +485,7 @@ class Camera(Sensor):
         self.colour = colour
         self.depth = depth
         self.depth_distance = depth_distance
+        self.depth_inverse = depth_inverse
         self.annotation = annotation
         self.instance = instance
 
@@ -733,9 +741,14 @@ class Camera(Sensor):
                 # between lightness values 0-255. Any distances outside
                 # of the scale are clamped to either 0 or 255
                 # respectively.
-                depth_d = np.interp(depth_d, [self.depth_distance[0],
-                            self.depth_distance[1]], [0, 255], left=0,
-                            right=255)
+                if self.depth_inverse:
+                    depth_d = np.interp(depth_d, [self.depth_distance[0],
+                              self.depth_distance[1]], [255, 0], left=255,
+                              right=0)
+                else:
+                    depth_d = np.interp(depth_d, [self.depth_distance[0],
+                              self.depth_distance[1]], [0, 255], left=0,
+                              right=255)
                 depth_d = depth_d.reshape(img_h, img_w)
                 depth_d = np.uint8(depth_d)
                 decoded['depth'] = Image.fromarray(depth_d)

--- a/src/beamngpy/sensors.py
+++ b/src/beamngpy/sensors.py
@@ -422,8 +422,8 @@ class Camera(Sensor):
         return color
 
     def __init__(self, pos, direction, fov, resolution, near_far=(NEAR, FAR),
-                 colour=False, depth=False, annotation=False, instance=False,
-                 shmem=True):
+                 colour=False, depth=False, depth_distance=(NEAR, FAR),
+                 annotation=False, instance=False, shmem=True):
         """
         The camera sensor is set up with a fixed offset position and
         directional vector to face relative to the vehicle. This means as the
@@ -455,6 +455,14 @@ class Camera(Sensor):
                               does not need to be changed.
             colour (bool): Whether to output colour information.
             depth (bool): Whether to output depth information.
+            depth_distance (tuple): (near,far) tuple of the distance range
+                                    depth values should be mapped between.
+                                    For example, a distance_scale of (10, 50)
+                                    would mean geometry closer than 10 would
+                                    be mapped to black and geometry further
+                                    than 50 would be mapped to white. All
+                                    distances in-between are interpolated
+                                    accordingly.
             annotation (bool): Whether to output annotation information.
             instance (bool): Whether to output instance annotation information.
             shmem (bool): Whether to use shared memory for sensor data
@@ -469,6 +477,7 @@ class Camera(Sensor):
 
         self.colour = colour
         self.depth = depth
+        self.depth_distance = depth_distance
         self.annotation = annotation
         self.instance = instance
 
@@ -665,6 +674,11 @@ class Camera(Sensor):
             decoded['depth'] = self.decode_image(resp['depth32F'],
                                                  img_w, img_h, 1,
                                                  dtype=np.float32)
+            # TODO: More needs to be done here to scale the lightness values
+			# between 0-255. Please see decode_shmem_response(). Currently
+			# this would generate an invalid image where each pixel's value
+			# would actually be a raw distance. I am unable to complete this
+            # as using shmem=False currently does not work for me.
 
         return decoded
 
@@ -715,9 +729,15 @@ class Camera(Sensor):
                 self.depth_shmem.seek(0)
                 depth_d = self.depth_shmem.read(size)
                 depth_d = np.frombuffer(depth_d, dtype=np.float32)
-                depth_d = depth_d / FAR
+                # Use linear interpolation to map the depth values
+                # between lightness values 0-255. Any distances outside
+                # of the scale are clamped to either 0 or 255
+                # respectively.
+                depth_d = np.interp(depth_d, [self.depth_distance[0],
+                            self.depth_distance[1]], [0, 255], left=0,
+                            right=255)
                 depth_d = depth_d.reshape(img_h, img_w)
-                depth_d = np.uint8(depth_d * 255)
+                depth_d = np.uint8(depth_d)
                 decoded['depth'] = Image.fromarray(depth_d)
             else:
                 print('Depth buffer failed to render. Check that you '

--- a/src/beamngpy/sensors.py
+++ b/src/beamngpy/sensors.py
@@ -683,9 +683,9 @@ class Camera(Sensor):
                                                  img_w, img_h, 1,
                                                  dtype=np.float32)
             # TODO: More needs to be done here to scale the lightness values
-			# between 0-255. Please see decode_shmem_response(). Currently
-			# this would generate an invalid image where each pixel's value
-			# would actually be a raw distance. I am unable to complete this
+            # between 0-255. Please see decode_shmem_response(). Currently
+            # this would generate an invalid image where each pixel's value
+            # would actually be a raw distance. I am unable to complete this
             # as using shmem=False currently does not work for me.
 
         return decoded


### PR DESCRIPTION
This pull request addresses two main issues:

1. The `near_far` parameter for the [Camera](https://beamngpy.readthedocs.io/en/latest/api/beamngpy.html#beamngpy.sensors.Camera) was resulting in an incorrect lightness scale for any other values than the default (0.01, 1000) setting.
2. Camera clipping and lightness depth value scaling should be separated so that `near_far` is only concerned with camera clipping, and a new parameter `depth_distance` is used to specify the minimum and maximum distance that lightness values 0-255 scale to.

This pull request also adds a new feature, the `depth_inverse` boolean flag, this causes geometry closer to the camera to be white instead of black and vice versa. This is a more representative of the standard output of a real-life stereo camera depth image. This would allow for pre-trained neural networks to not need retraining.

Here is a comparison of the resulting depth images before and after this pull request for different values:

![image](https://user-images.githubusercontent.com/2222870/107866187-cf15d980-6e65-11eb-9daf-1193db4b9e77.png)

![image](https://user-images.githubusercontent.com/2222870/107866412-86abeb00-6e68-11eb-8923-a9be5762a7a9.png)

![image](https://user-images.githubusercontent.com/2222870/107866486-7cd6b780-6e69-11eb-9298-20c296b435cd.png)

The below image shows the effects of specifying `depth_inverse = True`:

![image](https://user-images.githubusercontent.com/2222870/107866594-814fa000-6e6a-11eb-8b1d-2762a885bce1.png)
