### PR TITLE
Fix zero-value control requests being ignored.

### DIFF
--- a/src/beamngpy/api/vehicle/root.py
+++ b/src/beamngpy/api/vehicle/root.py
@@ -34,17 +34,17 @@ class RootApi(VehicleApi):
     def control(self, steering: float | None = None, throttle: float | None = None, brake: float | None = None,
                 parkingbrake: float | None = None, clutch: float | None = None, gear: int | None = None) -> None:
         options = {}
-        if steering:
+        if steering is not None:
             options['steering'] = steering
-        if throttle:
+        if throttle is not None:
             options['throttle'] = throttle
-        if brake:
+        if brake is not None:
             options['brake'] = brake
-        if parkingbrake:
+        if parkingbrake is not None:
             options['parkingbrake'] = parkingbrake
-        if clutch:
+        if clutch is not None:
             options['clutch'] = clutch
-        if gear:
+        if gear is not None:
             options['gear'] = gear
 
         data = dict(type='Control', **options)


### PR DESCRIPTION
This pull request fixes a bug that is currently causing vehicle control requests of values equal to zero to be totally ignored.

For example, if a user had previously requested a steering request of -1, and then subsequently sends a request of 0, the wheels of the vehicle would not re-center.

A very basic bug and I'm surprised it's gone unnoticed for so long!