### PR TITLE
fix: Update binary paths for BeamNG v0.33

### DIFF
--- a/src/beamngpy/beamng/filesystem.py
+++ b/src/beamngpy/beamng/filesystem.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 from beamngpy.logging import LOGGER_ID, BNGError, BNGValueError
 
-BINARIES = ['Bin64/BeamNG.tech.x64.exe', 'Bin64/BeamNG.drive.x64.exe']
-BINARIES_LINUX = ['BinLinux/BeamNG.tech.x64', 'BinLinux/BeamNG.drive.x64']
+BINARIES = ['Bin64/BeamNG.tech.x64.exe', 'Bin64/BeamNG.drive.x64.exe', 'Bin64/BeamNG.x64.exe']
+BINARIES_LINUX = ['BinLinux/BeamNG.tech.x64', 'BinLinux/BeamNG.drive.x64', 'BinLinux/BeamNG.x64']
 
 logger = logging.getLogger(f'{LOGGER_ID}.BeamNGpy')
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
BeamNG.drive v0.33 renames `'Bin64/BeamNG.drive.x64.exe'` -> `'Bin64/BeamNG.x64.exe'` and `'BinLinux/BeamNG.drive.x64'` -> `'BinLinux/BeamNG.x64'`. This PR adds the new names to the `BINARIES` and `BINARIES_LINUX` so they can be found.

![image](https://github.com/user-attachments/assets/d3075eaa-459d-4b63-9682-dfa4312c04f1)
